### PR TITLE
SELC-2887 Modified assistance page and disable copy and paste

### DIFF
--- a/src/pages/Assistance/Assistance.tsx
+++ b/src/pages/Assistance/Assistance.tsx
@@ -172,11 +172,7 @@ const Assistance = () => {
     };
   };
 
-  const preventDefaultCopy = (e: React.ClipboardEvent<HTMLInputElement>) => {
-    e.preventDefault();
-  };
-
-  const preventDefaultPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+  const preventClipboardEvents = (e: React.ClipboardEvent<HTMLInputElement>) => {
     e.preventDefault();
   };
 
@@ -206,8 +202,8 @@ const Assistance = () => {
                   <CustomTextField
                     {...baseTextFieldProps('email', t('assistancePageForm.email.label'))}
                     size="small"
-                    onCopy={preventDefaultCopy}
-                    onPaste={preventDefaultPaste}
+                    onCopy={preventClipboardEvents}
+                    onPaste={preventClipboardEvents}
                   ></CustomTextField>
                 </Grid>
                 <Grid item xs={12}>
@@ -217,8 +213,8 @@ const Assistance = () => {
                       t('assistancePageForm.confirmEmail.label')
                     )}
                     size="small"
-                    onCopy={preventDefaultCopy}
-                    onPaste={preventDefaultPaste}
+                    onCopy={preventClipboardEvents}
+                    onPaste={preventClipboardEvents}
                   ></CustomTextField>
                 </Grid>
               </Grid>

--- a/src/pages/Assistance/Assistance.tsx
+++ b/src/pages/Assistance/Assistance.tsx
@@ -189,7 +189,7 @@ const Assistance = () => {
         display="flex"
         sx={{ backgroundColor: theme.palette.background.default }}
       >
-        <Grid item xs={6} sx={{ maxWidth: '684px' }}>
+        <Grid item xs={6} maxWidth={{ md: '684px' }}>
           <TitleBox
             title={t('assistancePageForm.title')}
             subTitle={t('assistancePageForm.subTitle')}

--- a/src/pages/Assistance/Assistance.tsx
+++ b/src/pages/Assistance/Assistance.tsx
@@ -172,6 +172,14 @@ const Assistance = () => {
     };
   };
 
+  const preventDefaultCopy = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+  };
+
+  const preventDefaultPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+  };
+
   return (
     <Grid container xs={12}>
       <Grid
@@ -181,7 +189,7 @@ const Assistance = () => {
         display="flex"
         sx={{ backgroundColor: theme.palette.background.default }}
       >
-        <Grid item xs={6}>
+        <Grid item xs={6} sx={{ maxWidth: '684px' }}>
           <TitleBox
             title={t('assistancePageForm.title')}
             subTitle={t('assistancePageForm.subTitle')}
@@ -194,10 +202,12 @@ const Assistance = () => {
           <form onSubmit={formik.handleSubmit}>
             <Paper sx={{ p: 3, borderRadius: theme.spacing(0.5) }}>
               <Grid container item direction="column" spacing={3}>
-                <Grid item xs={12}>
+                <Grid item xs={12} pb={1}>
                   <CustomTextField
                     {...baseTextFieldProps('email', t('assistancePageForm.email.label'))}
                     size="small"
+                    onCopy={preventDefaultCopy}
+                    onPaste={preventDefaultPaste}
                   ></CustomTextField>
                 </Grid>
                 <Grid item xs={12}>
@@ -207,6 +217,8 @@ const Assistance = () => {
                       t('assistancePageForm.confirmEmail.label')
                     )}
                     size="small"
+                    onCopy={preventDefaultCopy}
+                    onPaste={preventDefaultPaste}
                   ></CustomTextField>
                 </Grid>
               </Grid>


### PR DESCRIPTION
#### List of Changes

Add max width on form.
Add more space beetween input fields
Disable copy and paste on input fields

#### Motivation and Context

Max width was added beacuse on big screens the responsive form rows became to big.
More space was added between input following figma design
Disabled copy and paste so the user its forced to write manually the email on both fields.

#### How Has This Been Tested?

Run application locally
Check in responsive mode for bigger screen 
Write on input fields and try copy and paste

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.