### PR TITLE
Release dev

### DIFF
--- a/.env.test.local
+++ b/.env.test.local
@@ -6,6 +6,7 @@ REACT_APP_URL_FE_DASHBOARD=http://selfcare/DashboardApi
 REACT_APP_URL_FE_LANDING=http://selfcare/landing
 
 REACT_APP_URL_API_ASSISTANCE=http://api.selfcare/assistance
+REACT_APP_URL_API_DASHBOARD=https://api.dev.selfcare.pagopa.it/dashboard/v1
 
 REACT_APP_API_MOCK_ASSISTANCE=false
 

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -20,6 +20,7 @@ export default {
     },
     back: 'Indietro',
     forward: 'Avanti',
+    linkPrivacyPolicy: 'Proseguendo dichiari di aver letto la <1>Privacy Policy Assistenza</1>',
   },
   thankyouPage: {
     title: 'Abbiamo ricevuto la tua <1/> richiesta',

--- a/src/pages/Assistance/Assistance.tsx
+++ b/src/pages/Assistance/Assistance.tsx
@@ -1,21 +1,24 @@
-import { useEffect, useRef } from 'react';
-import { Box, Button, Grid, Paper, TextField, useTheme } from '@mui/material';
-import { useFormik } from 'formik';
+import { Box, Button, Grid, Link, Paper, TextField, Typography, useTheme } from '@mui/material';
 import { styled } from '@mui/system';
 import TitleBox from '@pagopa/selfcare-common-frontend/components/TitleBox';
-import { AppError } from '@pagopa/selfcare-common-frontend/redux/slices/appStateSlice';
+import withLogin from '@pagopa/selfcare-common-frontend/decorators/withLogin';
 import useLoading from '@pagopa/selfcare-common-frontend/hooks/useLoading';
-import { appStateActions } from '@pagopa/selfcare-common-frontend/redux/slices/appStateSlice';
 import {
   useUnloadEventInterceptor,
   useUnloadEventOnExit,
 } from '@pagopa/selfcare-common-frontend/hooks/useUnloadEventInterceptor';
-import { uniqueId } from 'lodash';
+import {
+  AppError,
+  appStateActions,
+} from '@pagopa/selfcare-common-frontend/redux/slices/appStateSlice';
 import { trackEvent } from '@pagopa/selfcare-common-frontend/services/analyticsService';
-import { useTranslation } from 'react-i18next';
-import withLogin from '@pagopa/selfcare-common-frontend/decorators/withLogin';
+import { useFormik } from 'formik';
+import { uniqueId } from 'lodash';
+import { useEffect, useRef } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import { sendRequestToSupport } from '../../services/assistanceService';
 import { LOADING_TASK_SAVE_ASSISTANCE } from '../../utils/constants';
+import { ENV } from '../../utils/env';
 import { useAppDispatch } from './../../redux/hooks';
 
 export type AssistanceRequest = {
@@ -208,7 +211,18 @@ const Assistance = () => {
                 </Grid>
               </Grid>
             </Paper>
-            <Box my={5} display="flex" justifyContent="space-between">
+            <Typography variant="body2" mt={2} color={theme.palette.text.secondary}>
+              <Trans i18nKey="assistancePageForm.linkPrivacyPolicy">
+                Proseguendo dichiari di aver letto la
+                <Link
+                  sx={{ cursor: 'pointer', textDecoration: 'none' }}
+                  href={ENV.URL_FILE.PRIVACY_POLICY}
+                >
+                  Privacy Policy Assistenza
+                </Link>
+              </Trans>
+            </Typography>
+            <Box my={4} display="flex" justifyContent="space-between">
               <Box>
                 <Button
                   color="primary"

--- a/src/pages/Assistance/Assistance.tsx
+++ b/src/pages/Assistance/Assistance.tsx
@@ -172,6 +172,10 @@ const Assistance = () => {
     };
   };
 
+  const preventClipboardEvents = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+  };
+
   return (
     <Grid container xs={12}>
       <Grid
@@ -181,7 +185,7 @@ const Assistance = () => {
         display="flex"
         sx={{ backgroundColor: theme.palette.background.default }}
       >
-        <Grid item xs={6}>
+        <Grid item xs={6} maxWidth={{ md: '684px' }}>
           <TitleBox
             title={t('assistancePageForm.title')}
             subTitle={t('assistancePageForm.subTitle')}
@@ -194,10 +198,12 @@ const Assistance = () => {
           <form onSubmit={formik.handleSubmit}>
             <Paper sx={{ p: 3, borderRadius: theme.spacing(0.5) }}>
               <Grid container item direction="column" spacing={3}>
-                <Grid item xs={12}>
+                <Grid item xs={12} pb={1}>
                   <CustomTextField
                     {...baseTextFieldProps('email', t('assistancePageForm.email.label'))}
                     size="small"
+                    onCopy={preventClipboardEvents}
+                    onPaste={preventClipboardEvents}
                   ></CustomTextField>
                 </Grid>
                 <Grid item xs={12}>
@@ -207,6 +213,8 @@ const Assistance = () => {
                       t('assistancePageForm.confirmEmail.label')
                     )}
                     size="small"
+                    onCopy={preventClipboardEvents}
+                    onPaste={preventClipboardEvents}
                   ></CustomTextField>
                 </Grid>
               </Grid>

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -10,6 +10,10 @@ export const ENV = {
     EMAIL: env.get('REACT_APP_PAGOPA_HELP_EMAIL').required().asString(),
   },
 
+  URL_FILE: {
+    PRIVACY_POLICY: 'https://www.pagopa.it/it/privacy-policy-assistenza/',
+  },
+
   URL_FE: {
     LOGIN: env.get('REACT_APP_URL_FE_LOGIN').required().asString(),
     LOGOUT: env.get('REACT_APP_URL_FE_LOGOUT').required().asString(),


### PR DESCRIPTION
Modified assistance page with a new link where the user can check the privacy policy. Disabled copy and paste on input fields so the user is forced to type the email on both fields and some graphical fixes to follow figma design.

#### List of Changes
In the assistance page add link to the Privacy Policy
Add new link to privacy policy [SELC-2887]
Add max width on form.
Add more space beetween input fields
Disable copy and paste on input fields

#### Motivation and Context
Allow the user to read the PagoPa assitance privacy policy
Max width was added beacuse on big screens the responsive form rows became to big.
More space was added between input following figma design
Disabled copy and paste so the user its forced to write manually the email on both fields.

#### How Has This Been Tested?

Login in DEV
check the link Privacy Policy Assistenza and click the link
Check in responsive mode for larger screens 1280px+
Write on input fields and try copy and paste.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-2887]: https://pagopa.atlassian.net/browse/SELC-2887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ