### PR TITLE
SELC-2969 add productId in assistance API payload

### DIFF
--- a/src/api/DashboardApiClient.ts
+++ b/src/api/DashboardApiClient.ts
@@ -36,10 +36,11 @@ const onRedirectToLogin = () =>
   );
 
 export const DashboardApi = {
-  sendSupportRequest: async (email: string): Promise<SupportResponse> => {
+  sendSupportRequest: async (email: string, productId: string): Promise<SupportResponse> => {
     const result = await apiClient.sendSupportRequestUsingPOST({
       body: {
         email: email as EmailString,
+        productId,
       },
     });
     return extractResponse(result, 200, onRedirectToLogin);

--- a/src/pages/Assistance/Assistance.tsx
+++ b/src/pages/Assistance/Assistance.tsx
@@ -110,7 +110,7 @@ const Assistance = () => {
     validate,
     onSubmit: (values: AssistanceRequest) => {
       setLoading(true);
-      sendRequestToSupport(values.email)
+      sendRequestToSupport(values.email, 'prod-selfcare')
         .then((response) => {
           if (response.redirectUrl) {
             trackEvent('CUSTOMER_CARE_CONTACT_SUCCESS', { request_id: requestIdRef.current });

--- a/src/services/assistanceService.ts
+++ b/src/services/assistanceService.ts
@@ -1,11 +1,14 @@
 import { DashboardApi } from '../api/DashboardApiClient';
 import { SupportResponse } from '../api/generated/b4f-dashboard/SupportResponse';
 
-export const sendRequestToSupport = async (email: string): Promise<SupportResponse> => {
+export const sendRequestToSupport = async (
+  email: string,
+  productId: string
+): Promise<SupportResponse> => {
   /* istanbul ignore if */
   if (process.env.REACT_APP_API_MOCK_ASSISTANCE === 'true') {
     return new Promise((resolve) => resolve({ redirectUrl: 'mockedUrl' }));
   } else {
-    return DashboardApi.sendSupportRequest(email);
+    return DashboardApi.sendSupportRequest(email, productId);
   }
 };


### PR DESCRIPTION
#### List of Changes

Add product id to prod-selfcare in the payload of support API call

#### Motivation and Context

Requested the product Id so in the external Zendesk page thet field can be prefilled.

#### How Has This Been Tested?

Run app locally.turn off mocks, use token from dev to make api call and check the rerender.

#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.