### PR TITLE
[SELC-3857] feat: The product provided in the API REST may also correspond to the backoffice of origin

### DIFF
--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -10,8 +10,7 @@ export default {
         "L’indirizzo email di conferma non è uguale all'indirizzo email inserito",
     },
     title: 'Come possiamo aiutarti?',
-    subTitle:
-      'Indica l’indirizzo email in cui desideri ricevere d’ora in poi le risposte dell’assistenza.',
+    subTitle: 'Indica l’indirizzo email in cui desideri ricevere le risposte dell’assistenza.',
     email: {
       label: 'Inserisci l’indirizzo email',
     },

--- a/src/pages/Assistance/Assistance.tsx
+++ b/src/pages/Assistance/Assistance.tsx
@@ -78,6 +78,9 @@ const Assistance = () => {
 
   const requestIdRef = useRef<string>();
 
+  const urlParams = new URLSearchParams(window.location.search);
+  const productIdByUrl = urlParams.get('productId');
+
   useEffect(() => {
     if (!requestIdRef.current) {
       // eslint-disable-next-line functional/immutable-data
@@ -110,13 +113,14 @@ const Assistance = () => {
     validate,
     onSubmit: (values: AssistanceRequest) => {
       const windowReference = window.open();
-      const product =
-        window.location.hostname?.startsWith('pnpg') ||
-        window.location.hostname?.startsWith('imprese')
-          ? 'pn-pg'
-          : 'selfcare';
+      const product = productIdByUrl
+        ? productIdByUrl
+        : window.location.hostname?.startsWith('pnpg') ||
+          window.location.hostname?.startsWith('imprese')
+        ? 'prod-pn-pg'
+        : 'prod-selfcare';
       setLoading(true);
-      sendRequestToSupport(values.email, 'prod-'.concat(product))
+      sendRequestToSupport(values.email, product)
         .then((response) => {
           if (response.redirectUrl) {
             const url = response.redirectUrl;
@@ -195,7 +199,7 @@ const Assistance = () => {
         display="flex"
         sx={{ backgroundColor: theme.palette.background.default }}
       >
-        <Grid item xs={6} maxWidth={{ md: '684px' }}>
+        <Grid item xs={6} alignContent="center" display="grid" maxWidth={{ md: '684px' }}>
           <TitleBox
             title={t('assistancePageForm.title')}
             subTitle={t('assistancePageForm.subTitle')}
@@ -243,6 +247,7 @@ const Assistance = () => {
             <Box my={4} display="flex" justifyContent="space-between">
               <Box>
                 <Button
+                  size="small"
                   color="primary"
                   variant="outlined"
                   onClick={() => onExit(() => history.go(-1))}
@@ -252,10 +257,11 @@ const Assistance = () => {
               </Box>
               <Box>
                 <Button
-                  disabled={!formik.dirty || !formik.isValid}
+                  size="small"
                   color="primary"
                   variant="contained"
                   type="submit"
+                  disabled={!formik.dirty || !formik.isValid}
                 >
                   {t('assistancePageForm.forward')}
                 </Button>


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
The product provided in the API REST may also correspond to the backoffice of origin

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
By centralizing Selfcare as the point of sending assistance requests, it was therefore necessary to make Zendesk aware of the backoffice from which the support request came. The product will arrive via query string parameter, in this way the frontend will retrieve it

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
The product will arrive via query string parameter, in this way the frontend will retrieve it. When in the url is present ?productId=productId, the value is saved and sended in the body of REST API


<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.